### PR TITLE
Disable Gradle daemon on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ jdk: openjdk8
 sudo: false
 os: linux
 
+install: ./gradlew :kotlin-fixture:assemble --no-daemon
+
 script:
-  - ./gradlew :kotlin-fixture:assemble --no-daemon
   - ./gradlew :kotlin-fixture:check --no-daemon
   - ./gradlew :kotlin-fixture:jacocoTestReport --no-daemon
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 os: linux
 
 script:
-  - ./gradlew :kotlin-fixture:assemble
-  - ./gradlew :kotlin-fixture:check
-  - ./gradlew :kotlin-fixture:jacocoTestReport
+  - ./gradlew :kotlin-fixture:assemble --no-daemon
+  - ./gradlew :kotlin-fixture:check --no-daemon
+  - ./gradlew :kotlin-fixture:jacocoTestReport --no-daemon
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
It is recommend to disable the Daemon for Continuous Integration and build server environments.

Reference: https://docs.gradle.org/current/userguide/gradle_daemon.html#when_should_i_not_use_the_gradle_daemon